### PR TITLE
style(task): improve button at-a-glance order on task page

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -51,7 +51,7 @@ export default ({ children }) => (
       </Menu>
     </Segment>
 
-    <Container style={{ marginTop: '3.2em' }}>
+    <Container style={{ marginTop: '5.2em' }}>
       <NoMetaMask />
       {children}
     </Container>

--- a/src/features/task/components/Task.js
+++ b/src/features/task/components/Task.js
@@ -81,16 +81,19 @@ export class Task extends Component {
                       <Item.Description>
                         Tags: <Tags tags={task.tags} />
                       </Item.Description>
-                      <Item.Description>
-                        Issue URL:
-                        <a className="" target="_blank" href={task.issueURL}>
-                          {task.issueURL}
-                        </a>
-                      </Item.Description>
                       <Item.Meta>
                         Created: {task.createdAt.toDateString()}
                       </Item.Meta>
-                      <Item.Extra>
+                      <Item.Extra style={{paddingTop:'2em'}}>
+                        <Button
+                          href={task.issueURL}
+                          target="_blank"
+                          color="grey"
+                          compact
+                          size="large"
+                        >
+                          View Discussion
+                        </Button>
                         <Button
                           as={Link}
                           to={`/pullrequests/add/${task._id}`}
@@ -135,19 +138,22 @@ const TaskRewardInput = ({
       <Form.Field required>
         <label>DID Token Reward Min: 0 Max: 5000</label>
         <Input
-          type="text"
+          type="number"
           placeholder="positive numeric reward value"
           onChange={event => onChangeReward(event)}
           name="reward"
           value={reward}
+          min="0"
+          max="5000"
+          autocomplete="false"
         />
       </Form.Field>
       <Button
         disabled={disabled}
-        inverted
-        size="small"
-        color="green"
         type="submit"
+        color="black"
+        compact
+        size="large"
       >
         Vote on Reward
       </Button>


### PR DESCRIPTION
```gherkin
Scenario: Add View Discussion button to tasks page
When I am viewing a task "/tasks/Add-"View-Discussion"-button-to-single-Task-page/1537648763415a3f2b106c0" 
When I see a gray button with the text "View Discussion"
And I click the button
Then a new window/tab opens with "https://github.com/Distense/distense-ui/issues/106"

Scenario: Reward input type changed from text to number
When I am viewing a task "/tasks/Add-"View-Discussion"-button-to-single-Task-page/1537648763415a3f2b106c0" 
When I see "input[reward]"
Then the attribute "type" is "number"
And the attribute "min" is "0"
And the attribute "max" is "5000"
```

### NOTES
- Pardon me filling this PR with out of scope work, just wanted to apply a few visual tweaks while I was at it.
- Resolves #106